### PR TITLE
Add missing headers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 // Some rights reserved.
 // This software is free software licensed under the terms of GPLv3. See COPYING
 // file that comes with the source code, or http://www.gnu.org/licenses/gpl.txt.
+#include <array>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/src/sentinel/sentinel.cpp
+++ b/src/sentinel/sentinel.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <stdexcept>
 #include <sstream>
 
 #include "sentinel/logging.h"


### PR DESCRIPTION
It compiles fine without them but certain toolchains require them
to be explicitly included
